### PR TITLE
Fix Memory Leak / Garbage Accumulation in LivingHurtEventHandler

### DIFF
--- a/src/main/java/net/lixir/vminus/events/LivingHurtEventHandler.java
+++ b/src/main/java/net/lixir/vminus/events/LivingHurtEventHandler.java
@@ -17,6 +17,13 @@ import java.util.List;
 
 @Mod.EventBusSubscriber
 public class LivingHurtEventHandler {
+    private List<ProtectionConfig> protectionTypes = List.of(
+            new ProtectionConfig(VMinusAttributes.FIRE_PROTECTION, new ResourceLocation(VMinus.ID, "protection/fire")),
+            new ProtectionConfig(VMinusAttributes.MAGIC_PROTECTION, new ResourceLocation(VMinus.ID, "protection/magic")),
+            new ProtectionConfig(VMinusAttributes.FALL_PROTECTION, new ResourceLocation(VMinus.ID, "protection/fall")),
+            new ProtectionConfig(VMinusAttributes.BLUNT_PROTECTION, new ResourceLocation(VMinus.ID, "protection/blunt"))
+    );
+    
     @SubscribeEvent(priority = EventPriority.HIGH)
     public static void onLivingHurt(LivingHurtEvent event) {
         Entity entity = event.getEntity();
@@ -26,14 +33,7 @@ public class LivingHurtEventHandler {
         DamageSource damageSource = event.getSource();
         float damage = event.getAmount();
 
-        List<ProtectionConfig> protectionTypes = List.of(
-                new ProtectionConfig(VMinusAttributes.FIRE_PROTECTION, new ResourceLocation(VMinus.ID, "protection/fire")),
-                new ProtectionConfig(VMinusAttributes.MAGIC_PROTECTION, new ResourceLocation(VMinus.ID, "protection/magic")),
-                new ProtectionConfig(VMinusAttributes.FALL_PROTECTION, new ResourceLocation(VMinus.ID, "protection/fall")),
-                new ProtectionConfig(VMinusAttributes.BLUNT_PROTECTION, new ResourceLocation(VMinus.ID, "protection/blunt"))
-        );
-
-        for (ProtectionConfig protectionConfig : protectionTypes) {
+        for (ProtectionConfig protectionConfig : this.protectionTypes) {
             damage = AttributeHelper.applyProtection(damage, livingEntity, damageSource, protectionConfig.attribute(), protectionConfig.damageTag());
         }
 


### PR DESCRIPTION
This PR fixes a potential memory leak / excess garbage acculumation that occurs every time a Living entity is hurt. 

While this wouldn't lead to full heap consumption and an OutOfMemoryError on its own, it will result in excessive garbage generation. This will lead to Garbage Collection events in the VM which could cause (if there's enough of these types of leaks) large stutters in tick time and lead to poor performance on servers, etc.

I haven't looked at the rest of the codebase to see if there are any similar issues (you'd know faster than I would anyway), but if there are, I would recommend also addressing them. In general, limiting the amount of duplicate objects you create is generally wise (especially Lists that only exist for lookups - by the way, an unordered Set such as a HashSet is generally considered faster/more efficient for things like .contains() calls).

Figured I'd point out this potential bad habit just in case it applies to other things you're working on (such as Detour - excited for that!). Should save you some headache down the road. I'm in the Discord under the same username if you have any irrelevant-to-this-PR questions or anything in that regard.